### PR TITLE
fix Snapshots::Services::SnapshotLinkScraper URL

### DIFF
--- a/lib/register_ingester_psc/snapshots/services/snapshot_link_scraper.rb
+++ b/lib/register_ingester_psc/snapshots/services/snapshot_link_scraper.rb
@@ -10,7 +10,7 @@ module RegisterIngesterPsc
     module Services
       class SnapshotLinkScraper
         FILENAME_REGEX = /^psc-snapshot-\d{4}-\d{2}-\d{2}_\d+of\d+.zip$/
-        SOURCE_URL     = 'http://download.companieshouse.gov.uk/en_pscdata.html'
+        SOURCE_URL     = 'https://download.companieshouse.gov.uk/en_pscdata.html'
 
         def initialize(http_adapter: Config::Adapters::HTTP_ADAPTER, source_url: SOURCE_URL)
           @http_adapter = http_adapter


### PR DESCRIPTION
Companies House appear to have changed the URL to HTTPS. Hurrah!