### PR TITLE
[#243] extend StreamIngester to crash on invalid timepoint

### DIFF
--- a/lib/register_ingester_psc/streams/apps/stream_ingester.rb
+++ b/lib/register_ingester_psc/streams/apps/stream_ingester.rb
@@ -37,6 +37,10 @@ module RegisterIngesterPsc
             @records_handler.handle_records([record])
             @redis.set(REDIS_TIMEPOINT, timepoint)
           end
+        rescue Streams::Clients::TimepointError
+          @logger.fatal 'INVALID TIMEPOINT'
+          @redis.del(REDIS_TIMEPOINT)
+          raise
         end
       end
     end


### PR DESCRIPTION
If the stream timepoint is invalid, such as if it is too far in the past, it cannot be used. In such a case, the stored timepoint is cleared from Redis, and the program crashes.

This approach is chosen rather than clearing the timepoint and continuing, since this should usually be an exceptional failure case, which merits bubbling up through whichever monitoring method is being used. Restarting the program is left to whatever is monitoring it.

References https://github.com/openownership/register/issues/243 .