### PR TITLE
[#246] build Procfile within invalid timepoint

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: bin/ingest-stream 1


### PR DESCRIPTION
For deploy to Heroku. Use invalid timepoint, so it will eventually crash rather than start writing to production.

References https://github.com/openownership/register/issues/246 .