### PR TITLE
[#246] fix Procfile invalid timepoint

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: bin/ingest-stream 1
+worker: bin/ingest-stream


### PR DESCRIPTION
This was broken on purpose, whilst deployment was set up. Fix so it can go live.

References https://github.com/openownership/register/issues/246 .