### PR TITLE
[#246] set stdout sync

### DIFF
--- a/bin/ingest-stream
+++ b/bin/ingest-stream
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+$stdout.sync = true
+
 require 'bundler/setup'
 
 require 'airbrake-ruby'


### PR DESCRIPTION
I removed these from `lib/` previously, since I think they're better set in `bin/`, when they are needed. It seems to be needed here, since the latest lines aren't being reported in Heroku.

References https://github.com/openownership/register/issues/246 .