### PR TITLE
[#251] fix PscStream read_stream company_number regex

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/openownership/register-common.git
-  revision: cb5b5360a1aed6f832ea7ea631c85b1721dfeb07
+  revision: a1ffdbb52c56e7b92f66b726d9e0ce807ab77857
   specs:
     register_common (0.1.0)
       activesupport (>= 6, < 8)

--- a/lib/register_ingester_psc/streams/clients/psc_stream.rb
+++ b/lib/register_ingester_psc/streams/clients/psc_stream.rb
@@ -33,7 +33,7 @@ module RegisterIngesterPsc
           ) do |content|
             timepoint_err = false
             parsed = JSON.parse(content, symbolize_names: true)
-            match = %r{/company/(?<company_number>\d+)/}.match(parsed[:resource_uri])
+            match = %r{/company/(?<company_number>\w+)/}.match(parsed[:resource_uri])
             parsed[:company_number] = match[:company_number] if match
             yield RegisterSourcesPsc::PscStream.new(**parsed)
           end


### PR DESCRIPTION
Otherwise, company numbers such as SC808869 are not detected, since they do not contain only digits.

References https://github.com/openownership/register/issues/251 , during which it was discovered as part of Transformer PSC streaming work.